### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/abaveja313/conduit/security/code-scanning/1](https://github.com/abaveja313/conduit/security/code-scanning/1)

To fix the problem, the workflow should have a `permissions` block that explicitly limits what the GITHUB_TOKEN can do during execution. In general, this can be set at the workflow (root) or at the job level. Since the error is shown at the `ci` job and there is no permissions block at the workflow root, the fix can be applied at either place. The safest and most conventional approach is to set the minimal necessary permissions at the root level, which then applies to all jobs (unless overridden), unless a particular job requires more. 

For most CI purposes where only code checkout and basic build/test steps are performed, `contents: read` is sufficient. If, in the future, any job or step requires more, the permissions can be increased locally as needed. 

Edit the existing `.github/workflows/ci.yml` file near the top, after the `name` and before `on`, to add:

```yaml
permissions:
  contents: read
```

This follows the suggested minimal permissions model, providing only read access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
