### PR TITLE
Research and plan ast-grep browser integration

### DIFF
--- a/apps/web/src/components/AstSearchPanel.tsx
+++ b/apps/web/src/components/AstSearchPanel.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { astService } from '@conduit/fs';
+import type { AstQuery, AstMatch, AstStats, SupportedLanguage, PatternTemplates } from '@conduit/fs';
+
+interface AstSearchPanelProps {
+  onMatchSelect?: (match: AstMatch) => void;
+  className?: string;
+}
+
+export default function AstSearchPanel({ onMatchSelect, className = '' }: AstSearchPanelProps) {
+  const [initialized, setInitialized] = useState(false);
+  const [initializing, setInitializing] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [matches, setMatches] = useState<AstMatch[]>([]);
+  const [stats, setStats] = useState<AstStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Search parameters
+  const [searchMode, setSearchMode] = useState<'pattern' | 'template'>('template');
+  const [pattern, setPattern] = useState('');
+  const [templateType, setTemplateType] = useState<'function' | 'class' | 'import' | 'variable'>('function');
+  const [selectedLanguage, setSelectedLanguage] = useState<SupportedLanguage | 'all'>('all');
+  const [maxResults, setMaxResults] = useState(100);
+  const [contextLines, setContextLines] = useState(2);
+  
+  // Available languages
+  const languages = astService.getSupportedLanguages();
+  const [templates, setTemplates] = useState<PatternTemplates | null>(null);
+  const [parsedLanguages, setParsedLanguages] = useState<SupportedLanguage[]>([]);
+
+  // Initialize AST service
+  const initialize = useCallback(async () => {
+    if (initialized || initializing) return;
+    
+    setInitializing(true);
+    setError(null);
+    
+    try {
+      const languagesToParse = selectedLanguage === 'all' 
+        ? languages 
+        : [selectedLanguage];
+      
+      const parsed = await astService.initialize({
+        languages: languagesToParse,
+        maxFiles: 1000
+      });
+      
+      setInitialized(true);
+      setParsedLanguages(astService.getParsedLanguages());
+      updateStats();
+      
+      console.log(`AST service initialized with ${parsed} parsed files`);
+    } catch (err) {
+      console.error('Failed to initialize AST service:', err);
+      setError(`Failed to initialize: ${err}`);
+    } finally {
+      setInitializing(false);
+    }
+  }, [selectedLanguage]);
+
+  // Update statistics
+  const updateStats = useCallback(() => {
+    const newStats = astService.getStats();
+    setStats(newStats);
+  }, []);
+
+  // Load pattern templates when language changes
+  useEffect(() => {
+    if (selectedLanguage !== 'all') {
+      const newTemplates = astService.getPatternTemplates(selectedLanguage);
+      setTemplates(newTemplates);
+    }
+  }, [selectedLanguage]);
+
+  // Perform search
+  const performSearch = useCallback(async () => {
+    if (!initialized) {
+      await initialize();
+    }
+    
+    setSearching(true);
+    setError(null);
+    setMatches([]);
+    
+    try {
+      let query: AstQuery;
+      
+      if (searchMode === 'pattern') {
+        // Custom pattern search
+        query = {
+          pattern,
+          language: selectedLanguage !== 'all' ? selectedLanguage : undefined,
+          maxResults,
+          contextLines
+        };
+      } else {
+        // Template-based search
+        if (!templates || selectedLanguage === 'all') {
+          setError('Please select a specific language for template search');
+          return;
+        }
+        
+        const templatePattern = templates[
+          templateType === 'function' ? 'functionDefinition' :
+          templateType === 'class' ? 'classDefinition' :
+          templateType === 'import' ? 'imports' :
+          'variableDeclaration'
+        ];
+        
+        query = {
+          pattern: templatePattern,
+          language: selectedLanguage,
+          maxResults,
+          contextLines
+        };
+      }
+      
+      const results = await astService.search(query);
+      setMatches(results);
+      updateStats();
+      
+      console.log(`Found ${results.length} matches`);
+    } catch (err) {
+      console.error('Search failed:', err);
+      setError(`Search failed: ${err}`);
+    } finally {
+      setSearching(false);
+    }
+  }, [initialized, initialize, searchMode, pattern, templateType, selectedLanguage, maxResults, contextLines, templates]);
+
+  // Handle match selection
+  const handleMatchClick = useCallback((match: AstMatch) => {
+    if (onMatchSelect) {
+      onMatchSelect(match);
+    }
+  }, [onMatchSelect]);
+
+  // Clear cache
+  const clearCache = useCallback(() => {
+    astService.clearCache();
+    setInitialized(false);
+    setMatches([]);
+    setParsedLanguages([]);
+    updateStats();
+  }, [updateStats]);
+
+  return (
+    <div className={`flex flex-col h-full ${className}`}>
+      {/* Header */}
+      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4">
+        <h2 className="text-lg font-semibold mb-4">AST-Based Code Search</h2>
+        
+        {/* Status */}
+        <div className="flex items-center gap-4 mb-4 text-sm">
+          <div className="flex items-center gap-2">
+            <div className={`w-2 h-2 rounded-full ${initialized ? 'bg-green-500' : initializing ? 'bg-yellow-500 animate-pulse' : 'bg-gray-400'}`} />
+            <span>{initialized ? 'Ready' : initializing ? 'Initializing...' : 'Not initialized'}</span>
+          </div>
+          {stats && (
+            <>
+              <span>Trees: {stats.cachedTrees}</span>
+              <span>Cache Hit Rate: {(stats.hitRate * 100).toFixed(1)}%</span>
+            </>
+          )}
+        </div>
+        
+        {/* Search Mode Toggle */}
+        <div className="flex gap-2 mb-4">
+          <button
+            onClick={() => setSearchMode('template')}
+            className={`px-3 py-1 rounded ${searchMode === 'template' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+          >
+            Templates
+          </button>
+          <button
+            onClick={() => setSearchMode('pattern')}
+            className={`px-3 py-1 rounded ${searchMode === 'pattern' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'}`}
+          >
+            Custom Pattern
+          </button>
+        </div>
+        
+        {/* Search Controls */}
+        <div className="space-y-3">
+          {/* Language Selection */}
+          <div>
+            <label className="block text-sm font-medium mb-1">Language</label>
+            <select
+              value={selectedLanguage}
+              onChange={(e) => setSelectedLanguage(e.target.value as SupportedLanguage | 'all')}
+              className="w-full px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800"
+            >
+              <option value="all">All Languages</option>
+              {languages.map(lang => (
+                <option key={lang} value={lang}>
+                  {lang.charAt(0).toUpperCase() + lang.slice(1)}
+                  {parsedLanguages.includes(lang) && ' ✓'}
+                </option>
+              ))}
+            </select>
+          </div>
+          
+          {/* Template Selection (when in template mode) */}
+          {searchMode === 'template' && (
+            <div>
+              <label className="block text-sm font-medium mb-1">Template</label>
+              <select
+                value={templateType}
+                onChange={(e) => setTemplateType(e.target.value as any)}
+                className="w-full px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800"
+                disabled={selectedLanguage === 'all'}
+              >
+                <option value="function">Function Definitions</option>
+                <option value="class">Class Definitions</option>
+                <option value="import">Import Statements</option>
+                <option value="variable">Variable Declarations</option>
+              </select>
+            </div>
+          )}
+          
+          {/* Pattern Input (when in pattern mode) */}
+          {searchMode === 'pattern' && (
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Tree-sitter Query Pattern
+                <a 
+                  href="https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-2 text-blue-500 hover:underline text-xs"
+                >
+                  Help
+                </a>
+              </label>
+              <textarea
+                value={pattern}
+                onChange={(e) => setPattern(e.target.value)}
+                placeholder="(function_declaration name: (identifier) @name)"
+                className="w-full px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 font-mono text-sm"
+                rows={3}
+              />
+            </div>
+          )}
+          
+          {/* Advanced Options */}
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium mb-1">Max Results</label>
+              <input
+                type="number"
+                value={maxResults}
+                onChange={(e) => setMaxResults(Number(e.target.value))}
+                min={1}
+                max={1000}
+                className="w-full px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800"
+              />
+            </div>
+            <div className="flex-1">
+              <label className="block text-sm font-medium mb-1">Context Lines</label>
+              <input
+                type="number"
+                value={contextLines}
+                onChange={(e) => setContextLines(Number(e.target.value))}
+                min={0}
+                max={10}
+                className="w-full px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800"
+              />
+            </div>
+          </div>
+          
+          {/* Action Buttons */}
+          <div className="flex gap-2">
+            <button
+              onClick={performSearch}
+              disabled={searching || initializing || (searchMode === 'pattern' && !pattern)}
+              className="flex-1 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {searching ? 'Searching...' : 'Search'}
+            </button>
+            {!initialized && (
+              <button
+                onClick={initialize}
+                disabled={initializing}
+                className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 disabled:bg-gray-400"
+              >
+                Initialize
+              </button>
+            )}
+            <button
+              onClick={clearCache}
+              className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+            >
+              Clear Cache
+            </button>
+          </div>
+        </div>
+        
+        {/* Error Display */}
+        {error && (
+          <div className="mt-3 p-2 bg-red-100 dark:bg-red-900/20 border border-red-300 dark:border-red-700 rounded text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
+      </div>
+      
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {matches.length > 0 ? (
+          <div className="space-y-3">
+            <div className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+              Found {matches.length} matches
+            </div>
+            {matches.map((match, idx) => (
+              <div
+                key={idx}
+                onClick={() => handleMatchClick(match)}
+                className="p-3 bg-gray-50 dark:bg-gray-900 rounded border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer"
+              >
+                <div className="flex justify-between items-start mb-2">
+                  <div className="font-mono text-sm text-blue-600 dark:text-blue-400">
+                    {match.path}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    Line {match.line}, Col {match.column}
+                  </div>
+                </div>
+                
+                <div className="bg-white dark:bg-gray-800 p-2 rounded border border-gray-300 dark:border-gray-600">
+                  {match.context ? (
+                    <pre className="text-xs font-mono overflow-x-auto">
+                      {match.context.before.map((line, i) => (
+                        <div key={`before-${i}`} className="text-gray-500">
+                          {line}
+                        </div>
+                      ))}
+                      <div className="bg-yellow-100 dark:bg-yellow-900/30">
+                        {match.context.line}
+                      </div>
+                      {match.context.after.map((line, i) => (
+                        <div key={`after-${i}`} className="text-gray-500">
+                          {line}
+                        </div>
+                      ))}
+                    </pre>
+                  ) : (
+                    <pre className="text-xs font-mono overflow-x-auto">
+                      {match.text}
+                    </pre>
+                  )}
+                </div>
+                
+                <div className="mt-2 flex gap-2 text-xs">
+                  <span className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded">
+                    {match.language}
+                  </span>
+                  <span className="text-gray-500">
+                    {match.span.end - match.span.start} bytes
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : searching ? (
+          <div className="text-center text-gray-500 mt-8">
+            <div className="inline-block w-6 h-6 border-2 border-gray-400 border-t-transparent rounded-full animate-spin mb-2"></div>
+            <div>Searching...</div>
+          </div>
+        ) : (
+          <div className="text-center text-gray-500 mt-8">
+            {initialized ? 'No matches found. Try a different search.' : 'Initialize the service to start searching.'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/conduit-core/Cargo.toml
+++ b/crates/conduit-core/Cargo.toml
@@ -19,3 +19,12 @@ regex = "1.11.2"
 thiserror = "2.0.16"
 serde = { version = "1", features = ["derive", "rc"] }
 grep-matcher = "0.1.7"
+
+# Tree-sitter dependencies for AST parsing
+tree-sitter = "0.24"
+tree-sitter-rust = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-typescript = "0.24"
+tree-sitter-python = "0.24"
+tree-sitter-go = "0.23"
+tree-sitter-java = "0.23"

--- a/crates/conduit-core/src/ast/cache.rs
+++ b/crates/conduit-core/src/ast/cache.rs
@@ -1,0 +1,228 @@
+//! Cache management for parse trees to improve performance.
+
+use std::sync::Arc;
+use std::collections::HashMap;
+use parking_lot::RwLock;
+use crate::fs::PathKey;
+use super::{ParseTree, SupportedLanguage};
+
+/// Cache for parse trees to avoid re-parsing files.
+pub struct ParseTreeCache {
+    /// Cached parse trees by file path
+    trees: Arc<RwLock<HashMap<PathKey, CachedTree>>>,
+    /// Cache configuration
+    config: CacheConfig,
+    /// Cache statistics
+    stats: Arc<RwLock<CacheStats>>,
+}
+
+/// A cached parse tree with metadata.
+#[derive(Clone)]
+struct CachedTree {
+    /// The parse tree
+    tree: ParseTree,
+    /// Last modified time of the source file
+    mtime: i64,
+    /// Size of the source file
+    size: u64,
+    /// Number of times this tree has been accessed
+    access_count: usize,
+    /// Last access time (for LRU eviction)
+    last_access: std::time::Instant,
+}
+
+/// Configuration for the parse tree cache.
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    /// Maximum number of trees to cache
+    pub max_trees: usize,
+    /// Maximum total memory usage in bytes
+    pub max_memory: usize,
+    /// Whether to use LRU eviction
+    pub use_lru: bool,
+    /// Time-to-live for cached trees in seconds
+    pub ttl_seconds: Option<u64>,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            max_trees: 1000,
+            max_memory: 512 * 1024 * 1024, // 512MB
+            use_lru: true,
+            ttl_seconds: Some(3600), // 1 hour
+        }
+    }
+}
+
+/// Statistics about cache usage.
+#[derive(Debug, Clone, Default)]
+pub struct CacheStats {
+    /// Number of cache hits
+    pub hits: usize,
+    /// Number of cache misses
+    pub misses: usize,
+    /// Number of evictions
+    pub evictions: usize,
+    /// Current number of cached trees
+    pub tree_count: usize,
+    /// Current memory usage in bytes
+    pub memory_usage: usize,
+}
+
+impl ParseTreeCache {
+    /// Create a new parse tree cache with default configuration.
+    pub fn new() -> Self {
+        Self::with_config(CacheConfig::default())
+    }
+    
+    /// Create a new parse tree cache with custom configuration.
+    pub fn with_config(config: CacheConfig) -> Self {
+        Self {
+            trees: Arc::new(RwLock::new(HashMap::new())),
+            config,
+            stats: Arc::new(RwLock::new(CacheStats::default())),
+        }
+    }
+    
+    /// Get a parse tree from the cache.
+    pub fn get(&self, path: &PathKey, mtime: i64, size: u64) -> Option<ParseTree> {
+        let mut trees = self.trees.write();
+        let mut stats = self.stats.write();
+        
+        if let Some(cached) = trees.get_mut(path) {
+            // Check if the cached tree is still valid
+            if cached.mtime == mtime && cached.size == size {
+                // Check TTL if configured
+                if let Some(ttl) = self.config.ttl_seconds {
+                    let age = cached.last_access.elapsed().as_secs();
+                    if age > ttl {
+                        trees.remove(path);
+                        stats.misses += 1;
+                        stats.tree_count = trees.len();
+                        return None;
+                    }
+                }
+                
+                // Update access metadata
+                cached.access_count += 1;
+                cached.last_access = std::time::Instant::now();
+                
+                stats.hits += 1;
+                return Some(cached.tree.clone());
+            } else {
+                // File has changed, remove stale entry
+                trees.remove(path);
+                stats.tree_count = trees.len();
+            }
+        }
+        
+        stats.misses += 1;
+        None
+    }
+    
+    /// Insert a parse tree into the cache.
+    pub fn insert(&self, path: PathKey, tree: ParseTree, mtime: i64, size: u64) {
+        let mut trees = self.trees.write();
+        let mut stats = self.stats.write();
+        
+        // Check if we need to evict entries
+        if trees.len() >= self.config.max_trees {
+            self.evict_one(&mut trees, &mut stats);
+        }
+        
+        // Check memory usage
+        let tree_memory = self.estimate_memory(&tree);
+        if stats.memory_usage + tree_memory > self.config.max_memory {
+            self.evict_until_memory_available(&mut trees, &mut stats, tree_memory);
+        }
+        
+        let cached = CachedTree {
+            tree,
+            mtime,
+            size,
+            access_count: 0,
+            last_access: std::time::Instant::now(),
+        };
+        
+        trees.insert(path, cached);
+        stats.tree_count = trees.len();
+        stats.memory_usage += tree_memory;
+    }
+    
+    /// Clear all cached parse trees.
+    pub fn clear(&self) {
+        let mut trees = self.trees.write();
+        let mut stats = self.stats.write();
+        
+        trees.clear();
+        stats.tree_count = 0;
+        stats.memory_usage = 0;
+        stats.evictions += trees.len();
+    }
+    
+    /// Get cache statistics.
+    pub fn stats(&self) -> CacheStats {
+        self.stats.read().clone()
+    }
+    
+    /// Get cache hit rate (0.0 to 1.0).
+    pub fn hit_rate(&self) -> f64 {
+        let stats = self.stats.read();
+        let total = stats.hits + stats.misses;
+        if total == 0 {
+            0.0
+        } else {
+            stats.hits as f64 / total as f64
+        }
+    }
+    
+    /// Evict one entry using LRU policy.
+    fn evict_one(
+        &self,
+        trees: &mut HashMap<PathKey, CachedTree>,
+        stats: &mut CacheStats,
+    ) {
+        if !self.config.use_lru || trees.is_empty() {
+            return;
+        }
+        
+        // Find the least recently used entry
+        let lru_key = trees
+            .iter()
+            .min_by_key(|(_, cached)| cached.last_access)
+            .map(|(key, _)| key.clone());
+        
+        if let Some(key) = lru_key {
+            if let Some(cached) = trees.remove(&key) {
+                stats.memory_usage = stats.memory_usage.saturating_sub(self.estimate_memory(&cached.tree));
+                stats.evictions += 1;
+            }
+        }
+    }
+    
+    /// Evict entries until enough memory is available.
+    fn evict_until_memory_available(
+        &self,
+        trees: &mut HashMap<PathKey, CachedTree>,
+        stats: &mut CacheStats,
+        required: usize,
+    ) {
+        while stats.memory_usage + required > self.config.max_memory && !trees.is_empty() {
+            self.evict_one(trees, stats);
+        }
+    }
+    
+    /// Estimate memory usage of a parse tree.
+    fn estimate_memory(&self, tree: &ParseTree) -> usize {
+        // Rough estimate: source size + overhead for tree nodes
+        // Tree nodes typically add 2-3x overhead
+        tree.source().len() * 3
+    }
+}
+
+impl Default for ParseTreeCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/conduit-core/src/ast/language.rs
+++ b/crates/conduit-core/src/ast/language.rs
@@ -1,0 +1,123 @@
+//! Language configuration and support for AST parsing.
+
+use tree_sitter::Language;
+use crate::error::{Error, Result};
+
+/// Supported programming languages for AST-based search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SupportedLanguage {
+    JavaScript,
+    TypeScript,
+    Rust,
+    Python,
+    Go,
+    Java,
+}
+
+impl SupportedLanguage {
+    /// Get all supported languages.
+    pub fn all() -> &'static [SupportedLanguage] {
+        &[
+            SupportedLanguage::JavaScript,
+            SupportedLanguage::TypeScript,
+            SupportedLanguage::Rust,
+            SupportedLanguage::Python,
+            SupportedLanguage::Go,
+            SupportedLanguage::Java,
+        ]
+    }
+    
+    /// Detect language from file extension.
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext.to_lowercase().as_str() {
+            "js" | "mjs" | "cjs" => Some(SupportedLanguage::JavaScript),
+            "jsx" => Some(SupportedLanguage::JavaScript),
+            "ts" | "mts" | "cts" => Some(SupportedLanguage::TypeScript),
+            "tsx" => Some(SupportedLanguage::TypeScript),
+            "rs" => Some(SupportedLanguage::Rust),
+            "py" | "pyw" => Some(SupportedLanguage::Python),
+            "go" => Some(SupportedLanguage::Go),
+            "java" => Some(SupportedLanguage::Java),
+            _ => None,
+        }
+    }
+    
+    /// Get the tree-sitter language for this language.
+    pub fn tree_sitter_language(&self) -> Language {
+        unsafe {
+            match self {
+                SupportedLanguage::JavaScript => tree_sitter_javascript::LANGUAGE,
+                SupportedLanguage::TypeScript => tree_sitter_typescript::LANGUAGE_TSX,
+                SupportedLanguage::Rust => tree_sitter_rust::LANGUAGE,
+                SupportedLanguage::Python => tree_sitter_python::LANGUAGE,
+                SupportedLanguage::Go => tree_sitter_go::LANGUAGE,
+                SupportedLanguage::Java => tree_sitter_java::LANGUAGE,
+            }
+        }
+    }
+    
+    
+    /// Get the display name for this language.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            SupportedLanguage::JavaScript => "JavaScript",
+            SupportedLanguage::TypeScript => "TypeScript",
+            SupportedLanguage::Rust => "Rust",
+            SupportedLanguage::Python => "Python",
+            SupportedLanguage::Go => "Go",
+            SupportedLanguage::Java => "Java",
+        }
+    }
+    
+    /// Get the file extensions for this language.
+    pub fn extensions(&self) -> &'static [&'static str] {
+        match self {
+            SupportedLanguage::JavaScript => &["js", "mjs", "cjs", "jsx"],
+            SupportedLanguage::TypeScript => &["ts", "tsx", "mts", "cts"],
+            SupportedLanguage::Rust => &["rs"],
+            SupportedLanguage::Python => &["py", "pyw"],
+            SupportedLanguage::Go => &["go"],
+            SupportedLanguage::Java => &["java"],
+        }
+    }
+}
+
+/// Configuration for language-specific AST operations.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LanguageConfig {
+    /// The language
+    pub language: SupportedLanguage,
+    /// Whether to enable incremental parsing
+    pub incremental: bool,
+    /// Maximum file size to parse (in bytes)
+    pub max_file_size: usize,
+    /// Whether to cache parse trees
+    pub cache_enabled: bool,
+}
+
+impl Default for LanguageConfig {
+    fn default() -> Self {
+        Self {
+            language: SupportedLanguage::JavaScript,
+            incremental: true,
+            max_file_size: 10 * 1024 * 1024, // 10MB
+            cache_enabled: true,
+        }
+    }
+}
+
+impl LanguageConfig {
+    /// Create a new language configuration.
+    pub fn new(language: SupportedLanguage) -> Self {
+        Self {
+            language,
+            ..Default::default()
+        }
+    }
+    
+    /// Check if a file should be parsed based on its size.
+    pub fn should_parse(&self, file_size: usize) -> bool {
+        file_size <= self.max_file_size
+    }
+}

--- a/crates/conduit-core/src/ast/mod.rs
+++ b/crates/conduit-core/src/ast/mod.rs
@@ -1,0 +1,98 @@
+//! AST-based search functionality using tree-sitter.
+//!
+//! This module provides structural code search capabilities across multiple languages,
+//! enabling pattern-based searches that understand code syntax and structure.
+
+use std::sync::Arc;
+use tree_sitter::{Language, Parser, Tree};
+use crate::error::{Error, Result};
+use crate::fs::PathKey;
+
+pub mod language;
+pub mod search;
+pub mod cache;
+pub mod pattern;
+
+pub use language::{SupportedLanguage, LanguageConfig};
+pub use search::{AstSearcher, AstQuery, AstMatch};
+pub use cache::ParseTreeCache;
+pub use pattern::{Pattern, PatternMatcher};
+
+/// Parse tree wrapper that holds the parsed AST and its metadata.
+#[derive(Clone)]
+pub struct ParseTree {
+    /// The tree-sitter parse tree
+    tree: Arc<Tree>,
+    /// The original source code
+    source: Arc<[u8]>,
+    /// The language used for parsing
+    language: SupportedLanguage,
+    /// Path of the source file
+    path: PathKey,
+}
+
+impl ParseTree {
+    /// Create a new parse tree from source code.
+    pub fn parse(
+        source: Arc<[u8]>,
+        language: SupportedLanguage,
+        path: PathKey,
+    ) -> Result<Self> {
+        let mut parser = Parser::new();
+        let ts_language = language.tree_sitter_language();
+        
+        parser.set_language(ts_language)
+            .map_err(|e| Error::ParseError(format!("Failed to set language: {}", e)))?;
+        
+        let tree = parser.parse(&source[..], None)
+            .ok_or_else(|| Error::ParseError("Failed to parse source code".into()))?;
+        
+        Ok(Self {
+            tree: Arc::new(tree),
+            source,
+            language,
+            path,
+        })
+    }
+    
+    /// Get the root node of the parse tree.
+    pub fn root_node(&self) -> tree_sitter::Node {
+        self.tree.root_node()
+    }
+    
+    /// Get the source code.
+    pub fn source(&self) -> &[u8] {
+        &self.source
+    }
+    
+    /// Get the language.
+    pub fn language(&self) -> SupportedLanguage {
+        self.language
+    }
+    
+    /// Get the file path.
+    pub fn path(&self) -> &PathKey {
+        &self.path
+    }
+    
+    /// Get the source as a string (if valid UTF-8).
+    pub fn source_str(&self) -> Result<&str> {
+        std::str::from_utf8(&self.source)
+            .map_err(|e| Error::ParseError(format!("Invalid UTF-8 in source: {}", e)))
+    }
+}
+
+/// Statistics about AST operations.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct AstStats {
+    /// Number of files parsed
+    pub files_parsed: usize,
+    /// Number of parse trees cached
+    pub trees_cached: usize,
+    /// Total parsing time in milliseconds
+    pub parse_time_ms: u64,
+    /// Total search time in milliseconds
+    pub search_time_ms: u64,
+    /// Cache hit rate (0.0 to 1.0)
+    pub cache_hit_rate: f64,
+}

--- a/crates/conduit-core/src/ast/pattern.rs
+++ b/crates/conduit-core/src/ast/pattern.rs
@@ -1,0 +1,195 @@
+//! Pattern matching for AST nodes using tree-sitter queries.
+
+use tree_sitter::{Node, Query, QueryCursor, QueryMatch};
+use crate::error::{Error, Result};
+use super::SupportedLanguage;
+
+/// A pattern for matching AST nodes.
+#[derive(Debug, Clone)]
+pub struct Pattern {
+    /// The pattern string (tree-sitter query syntax)
+    pattern: String,
+    /// The language this pattern is for
+    language: SupportedLanguage,
+}
+
+impl Pattern {
+    /// Create a new pattern.
+    pub fn new(pattern: impl Into<String>, language: SupportedLanguage) -> Self {
+        Self {
+            pattern: pattern.into(),
+            language,
+        }
+    }
+    
+    /// Get the pattern string.
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+    
+    /// Get the language.
+    pub fn language(&self) -> SupportedLanguage {
+        self.language
+    }
+    
+    /// Compile this pattern into a tree-sitter query.
+    pub fn compile(&self) -> Result<Query> {
+        let ts_language = self.language.tree_sitter_language();
+        Query::new(&ts_language, &self.pattern)
+            .map_err(|e| Error::ParseError(format!("Invalid pattern: {}", e)))
+    }
+}
+
+/// Pattern matcher that can find matches in AST nodes.
+pub struct PatternMatcher {
+    query: Query,
+    cursor: QueryCursor,
+}
+
+impl PatternMatcher {
+    /// Create a new pattern matcher from a pattern.
+    pub fn new(pattern: &Pattern) -> Result<Self> {
+        let query = pattern.compile()?;
+        let cursor = QueryCursor::new();
+        Ok(Self { query, cursor })
+    }
+    
+    /// Find all matches in the given node.
+    pub fn find_matches<'a>(
+        &'a mut self,
+        node: Node<'a>,
+        source: &'a [u8],
+    ) -> impl Iterator<Item = QueryMatch<'a, 'a>> + 'a {
+        self.cursor.matches(&self.query, node, source)
+    }
+    
+    /// Check if the pattern matches anywhere in the node.
+    pub fn has_match(&mut self, node: Node, source: &[u8]) -> bool {
+        self.cursor.matches(&self.query, node, source).next().is_some()
+    }
+    
+    /// Count the number of matches in the node.
+    pub fn count_matches(&mut self, node: Node, source: &[u8]) -> usize {
+        self.cursor.matches(&self.query, node, source).count()
+    }
+}
+
+/// Common pattern templates for different languages.
+pub mod templates {
+    use super::*;
+    
+    /// Create a pattern for finding function definitions.
+    pub fn function_definition(language: SupportedLanguage) -> Pattern {
+        let pattern = match language {
+            SupportedLanguage::JavaScript | SupportedLanguage::TypeScript => {
+                r#"[
+                    (function_declaration name: (identifier) @name)
+                    (arrow_function)
+                    (function_expression name: (identifier)? @name)
+                    (method_definition key: (property_identifier) @name)
+                ]"#
+            }
+            SupportedLanguage::Rust => {
+                r#"(function_item name: (identifier) @name)"#
+            }
+            SupportedLanguage::Python => {
+                r#"(function_definition name: (identifier) @name)"#
+            }
+            SupportedLanguage::Go => {
+                r#"[
+                    (function_declaration name: (identifier) @name)
+                    (method_declaration name: (field_identifier) @name)
+                ]"#
+            }
+            SupportedLanguage::Java => {
+                r#"(method_declaration name: (identifier) @name)"#
+            }
+        };
+        Pattern::new(pattern, language)
+    }
+    
+    /// Create a pattern for finding class definitions.
+    pub fn class_definition(language: SupportedLanguage) -> Pattern {
+        let pattern = match language {
+            SupportedLanguage::JavaScript | SupportedLanguage::TypeScript => {
+                r#"(class_declaration name: (identifier) @name)"#
+            }
+            SupportedLanguage::Rust => {
+                r#"[
+                    (struct_item name: (type_identifier) @name)
+                    (enum_item name: (type_identifier) @name)
+                    (trait_item name: (type_identifier) @name)
+                ]"#
+            }
+            SupportedLanguage::Python => {
+                r#"(class_definition name: (identifier) @name)"#
+            }
+            SupportedLanguage::Go => {
+                r#"(type_declaration (type_spec name: (type_identifier) @name))"#
+            }
+            SupportedLanguage::Java => {
+                r#"[
+                    (class_declaration name: (identifier) @name)
+                    (interface_declaration name: (identifier) @name)
+                ]"#
+            }
+        };
+        Pattern::new(pattern, language)
+    }
+    
+    /// Create a pattern for finding imports.
+    pub fn imports(language: SupportedLanguage) -> Pattern {
+        let pattern = match language {
+            SupportedLanguage::JavaScript | SupportedLanguage::TypeScript => {
+                r#"[
+                    (import_statement)
+                    (import_clause)
+                ]"#
+            }
+            SupportedLanguage::Rust => {
+                r#"(use_declaration)"#
+            }
+            SupportedLanguage::Python => {
+                r#"[
+                    (import_statement)
+                    (import_from_statement)
+                ]"#
+            }
+            SupportedLanguage::Go => {
+                r#"(import_declaration)"#
+            }
+            SupportedLanguage::Java => {
+                r#"(import_declaration)"#
+            }
+        };
+        Pattern::new(pattern, language)
+    }
+    
+    /// Create a pattern for finding variable declarations.
+    pub fn variable_declaration(language: SupportedLanguage) -> Pattern {
+        let pattern = match language {
+            SupportedLanguage::JavaScript | SupportedLanguage::TypeScript => {
+                r#"[
+                    (variable_declaration)
+                    (lexical_declaration)
+                ]"#
+            }
+            SupportedLanguage::Rust => {
+                r#"(let_declaration pattern: (identifier) @name)"#
+            }
+            SupportedLanguage::Python => {
+                r#"(assignment left: (identifier) @name)"#
+            }
+            SupportedLanguage::Go => {
+                r#"[
+                    (var_declaration)
+                    (short_var_declaration)
+                ]"#
+            }
+            SupportedLanguage::Java => {
+                r#"(variable_declarator name: (identifier) @name)"#
+            }
+        };
+        Pattern::new(pattern, language)
+    }
+}

--- a/crates/conduit-core/src/ast/search.rs
+++ b/crates/conduit-core/src/ast/search.rs
@@ -1,0 +1,268 @@
+//! AST-based search implementation using tree-sitter patterns.
+
+use std::sync::Arc;
+use tree_sitter::{Node, QueryMatch};
+use crate::error::{Error, Result};
+use crate::fs::PathKey;
+use crate::tools::model::ByteSpan;
+use super::{ParseTree, SupportedLanguage, Pattern, PatternMatcher};
+
+/// AST search query that can match structural patterns in code.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AstQuery {
+    /// The pattern to search for (ast-grep pattern syntax)
+    pub pattern: String,
+    /// Optional language filter
+    pub language: Option<SupportedLanguage>,
+    /// Maximum number of results to return
+    pub max_results: Option<usize>,
+    /// Include context lines around matches
+    pub context_lines: usize,
+}
+
+impl AstQuery {
+    /// Create a new AST query with the given pattern.
+    pub fn new(pattern: impl Into<String>) -> Self {
+        Self {
+            pattern: pattern.into(),
+            language: None,
+            max_results: None,
+            context_lines: 2,
+        }
+    }
+    
+    /// Set the language filter.
+    pub fn with_language(mut self, language: SupportedLanguage) -> Self {
+        self.language = Some(language);
+        self
+    }
+    
+    /// Set the maximum number of results.
+    pub fn with_max_results(mut self, max: usize) -> Self {
+        self.max_results = Some(max);
+        self
+    }
+    
+    /// Set the number of context lines.
+    pub fn with_context(mut self, lines: usize) -> Self {
+        self.context_lines = lines;
+        self
+    }
+}
+
+/// A match found by AST search.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AstMatch {
+    /// Path to the file containing the match
+    pub path: PathKey,
+    /// Byte span of the match in the source file
+    pub span: ByteSpan,
+    /// The matched text
+    pub text: String,
+    /// Line number where the match starts (1-based)
+    pub line: usize,
+    /// Column number where the match starts (1-based)
+    pub column: usize,
+    /// Language of the matched file
+    pub language: SupportedLanguage,
+    /// Optional context around the match
+    pub context: Option<MatchContext>,
+}
+
+/// Context around a match for better understanding.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MatchContext {
+    /// Lines before the match
+    pub before: Vec<String>,
+    /// The line containing the match
+    pub line: String,
+    /// Lines after the match
+    pub after: Vec<String>,
+}
+
+/// AST searcher that can execute queries over parse trees.
+pub struct AstSearcher {
+    /// Cached parse trees
+    trees: Vec<ParseTree>,
+    /// Search configuration
+    config: SearchConfig,
+}
+
+/// Configuration for AST search operations.
+#[derive(Debug, Clone)]
+pub struct SearchConfig {
+    /// Whether to search in parallel
+    pub parallel: bool,
+    /// Maximum number of threads for parallel search
+    pub max_threads: usize,
+    /// Whether to stop on first match
+    pub stop_on_first: bool,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            parallel: true,
+            max_threads: 4,
+            stop_on_first: false,
+        }
+    }
+}
+
+impl AstSearcher {
+    /// Create a new AST searcher.
+    pub fn new() -> Self {
+        Self {
+            trees: Vec::new(),
+            config: SearchConfig::default(),
+        }
+    }
+    
+    /// Create a searcher with custom configuration.
+    pub fn with_config(config: SearchConfig) -> Self {
+        Self {
+            trees: Vec::new(),
+            config,
+        }
+    }
+    
+    /// Add a parse tree to search.
+    pub fn add_tree(&mut self, tree: ParseTree) {
+        self.trees.push(tree);
+    }
+    
+    /// Add multiple parse trees.
+    pub fn add_trees(&mut self, trees: impl IntoIterator<Item = ParseTree>) {
+        self.trees.extend(trees);
+    }
+    
+    /// Execute a search query over all added parse trees.
+    pub fn search(&self, query: &AstQuery) -> Result<Vec<AstMatch>> {
+        let mut results = Vec::new();
+        let mut count = 0;
+        
+        for tree in &self.trees {
+            // Skip if language filter doesn't match
+            if let Some(lang) = query.language {
+                if tree.language() != lang {
+                    continue;
+                }
+            }
+            
+            // Create pattern matcher for this language
+            let pattern = Pattern::new(&query.pattern, tree.language());
+            let mut matcher = PatternMatcher::new(&pattern)?;
+            
+            // Find all matches in this tree
+            let root = tree.root_node();
+            let source = tree.source();
+            let matches = matcher.find_matches(root, source);
+            
+            for mat in matches {
+                if let Some(max) = query.max_results {
+                    if count >= max {
+                        return Ok(results);
+                    }
+                }
+                
+                // Get the first captured node or the root of the match
+                let node = if mat.captures.len() > 0 {
+                    mat.captures[0].node
+                } else {
+                    mat.pattern_index as usize;
+                    root
+                };
+                
+                let range = node.range();
+                let span = ByteSpan::try_new(range.start_byte, range.end_byte)?;
+                
+                let text = node.utf8_text(source)
+                    .map_err(|e| Error::ParseError(format!("Invalid UTF-8 in match: {}", e)))?
+                    .to_string();
+                
+                let start_pos = range.start_point;
+                let context = if query.context_lines > 0 {
+                    Some(self.extract_context(tree, &span, query.context_lines)?)
+                } else {
+                    None
+                };
+                
+                results.push(AstMatch {
+                    path: tree.path().clone(),
+                    span,
+                    text,
+                    line: start_pos.row + 1,
+                    column: start_pos.column + 1,
+                    language: tree.language(),
+                    context,
+                });
+                
+                count += 1;
+                
+                if self.config.stop_on_first {
+                    return Ok(results);
+                }
+            }
+        }
+        
+        Ok(results)
+    }
+    
+    /// Extract context lines around a match.
+    fn extract_context(
+        &self,
+        tree: &ParseTree,
+        span: &ByteSpan,
+        context_lines: usize,
+    ) -> Result<MatchContext> {
+        let source = std::str::from_utf8(tree.source())
+            .map_err(|e| Error::ParseError(format!("Invalid UTF-8 in source: {}", e)))?;
+        
+        let lines: Vec<&str> = source.lines().collect();
+        let byte_to_line = self.build_byte_to_line_map(source);
+        
+        let start_line = byte_to_line.get(&span.start).copied().unwrap_or(0);
+        let before_start = start_line.saturating_sub(context_lines);
+        let after_end = (start_line + context_lines + 1).min(lines.len());
+        
+        Ok(MatchContext {
+            before: lines[before_start..start_line]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            line: lines.get(start_line).unwrap_or(&"").to_string(),
+            after: lines[(start_line + 1)..after_end]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        })
+    }
+    
+    /// Build a map from byte offset to line number.
+    fn build_byte_to_line_map(&self, source: &str) -> std::collections::HashMap<usize, usize> {
+        let mut map = std::collections::HashMap::new();
+        let mut byte_offset = 0;
+        
+        for (line_num, line) in source.lines().enumerate() {
+            for _ in 0..line.len() {
+                map.insert(byte_offset, line_num);
+                byte_offset += 1;
+            }
+            // Account for newline
+            map.insert(byte_offset, line_num);
+            byte_offset += 1;
+        }
+        
+        map
+    }
+    
+    /// Clear all parse trees from the searcher.
+    pub fn clear(&mut self) {
+        self.trees.clear();
+    }
+    
+    /// Get the number of parse trees loaded.
+    pub fn tree_count(&self) -> usize {
+        self.trees.len()
+    }
+}

--- a/crates/conduit-core/src/error.rs
+++ b/crates/conduit-core/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
 
     #[error("invalid path provided: {0}")]
     InvalidPath(String),
+    
+    #[error("parse error: {0}")]
+    ParseError(String),
+    
+    #[error("AST operation error: {0}")]
+    AstError(String),
 
     // -------- Search / Replace / Preview --------
     #[error("invalid range: [{0}, {1})")]

--- a/crates/conduit-core/src/fs/index.rs
+++ b/crates/conduit-core/src/fs/index.rs
@@ -220,6 +220,11 @@ impl Index {
     pub fn is_empty(&self) -> bool {
         self.files.is_empty()
     }
+    
+    /// Iterate over all files.
+    pub fn iter_files(&self) -> impl Iterator<Item = (&PathKey, &FileEntry)> {
+        self.files.iter()
+    }
 
     /// Iterator over all files.
     pub fn iter(&self) -> impl Iterator<Item = (&PathKey, &FileEntry)> {

--- a/crates/conduit-core/src/lib.rs
+++ b/crates/conduit-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod fs;
 pub mod tools;
+pub mod ast;
 
 pub use error::{Error, Result};
 pub use fs::prelude::*;

--- a/crates/conduit-wasm/Cargo.toml
+++ b/crates/conduit-wasm/Cargo.toml
@@ -10,10 +10,21 @@ crate-type = ["cdylib"]
 conduit-core = { path = "../conduit-core" }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde-wasm-bindgen = "0.6"
 once_cell = "1.19"
 console_error_panic_hook = { version = "0.1", optional = true }
+
+# Tree-sitter dependencies for WASM
+tree-sitter = "0.24"
+tree-sitter-rust = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-typescript = "0.24"
+tree-sitter-python = "0.24"
+tree-sitter-go = "0.23"
+tree-sitter-java = "0.23"
 
 [features]
 default = ["console_error_panic_hook"]

--- a/crates/conduit-wasm/src/ast.rs
+++ b/crates/conduit-wasm/src/ast.rs
@@ -1,0 +1,273 @@
+//! WASM bindings for AST-based search functionality.
+
+use conduit_core::ast::{
+    AstMatch, AstQuery, AstSearcher, ParseTree, ParseTreeCache, Pattern, SupportedLanguage,
+};
+use conduit_core::fs::FileEntry;
+use js_sys::Array;
+use serde_wasm_bindgen::{from_value, to_value};
+use wasm_bindgen::prelude::*;
+use std::sync::Arc;
+
+use crate::globals::{create_path_key, get_index_manager};
+
+/// Global parse tree cache for performance.
+static PARSE_TREE_CACHE: once_cell::sync::Lazy<ParseTreeCache> = 
+    once_cell::sync::Lazy::new(ParseTreeCache::new);
+
+/// Parse files in the index and prepare them for AST search.
+/// Returns the number of files successfully parsed.
+#[wasm_bindgen]
+pub fn parse_indexed_files(
+    language_filter: Option<String>,
+    max_files: Option<usize>,
+) -> Result<usize, JsValue> {
+    let manager = get_index_manager();
+    let index = manager.active_index();
+    let mut parsed_count = 0;
+    let mut processed = 0;
+    
+    // Parse language filter if provided
+    let lang_filter = if let Some(lang_str) = language_filter {
+        Some(parse_language(&lang_str)?)
+    } else {
+        None
+    };
+    
+    // Iterate through files in the index
+    for (path, entry) in index.iter_files() {
+        if let Some(max) = max_files {
+            if processed >= max {
+                break;
+            }
+        }
+        
+        // Check if file has content
+        let content = match entry.bytes() {
+            Some(bytes) => bytes,
+            None => continue,
+        };
+        
+        // Detect language from extension
+        let ext = entry.ext();
+        let language = match SupportedLanguage::from_extension(ext) {
+            Some(lang) => lang,
+            None => continue,
+        };
+        
+        // Apply language filter
+        if let Some(filter) = lang_filter {
+            if language != filter {
+                continue;
+            }
+        }
+        
+        // Try to parse the file
+        match ParseTree::parse(Arc::from(content), language, path.clone()) {
+            Ok(tree) => {
+                // Cache the parse tree
+                PARSE_TREE_CACHE.insert(
+                    path.clone(),
+                    tree,
+                    entry.mtime(),
+                    entry.size(),
+                );
+                parsed_count += 1;
+            }
+            Err(e) => {
+                // Log parse error but continue
+                web_sys::console::warn_1(
+                    &format!("Failed to parse {}: {}", path.as_str(), e).into()
+                );
+            }
+        }
+        
+        processed += 1;
+    }
+    
+    Ok(parsed_count)
+}
+
+/// Search for patterns in parsed files using AST queries.
+/// Returns an array of matches.
+#[wasm_bindgen]
+pub fn ast_search(query_json: &str) -> Result<JsValue, JsValue> {
+    // Parse the query
+    let query: AstQuery = serde_json::from_str(query_json)
+        .map_err(|e| JsValue::from_str(&format!("Invalid query: {}", e)))?;
+    
+    // Create searcher and add cached trees
+    let mut searcher = AstSearcher::new();
+    let cache_stats = PARSE_TREE_CACHE.stats();
+    
+    // Get trees from cache (we'll need to modify cache to expose trees)
+    // For now, re-parse from index
+    let manager = get_index_manager();
+    let index = manager.active_index();
+    
+    for (path, entry) in index.iter_files() {
+        // Check if we have a cached tree
+        if let Some(tree) = PARSE_TREE_CACHE.get(&path, entry.mtime(), entry.size()) {
+            searcher.add_tree(tree);
+        }
+    }
+    
+    // Execute search
+    let matches = searcher.search(&query)
+        .map_err(|e| JsValue::from_str(&format!("Search failed: {}", e)))?;
+    
+    // Convert matches to JS array
+    let js_array = Array::new();
+    for match_result in matches {
+        let js_match = to_value(&match_result)
+            .map_err(|e| JsValue::from_str(&format!("Serialization failed: {}", e)))?;
+        js_array.push(&js_match);
+    }
+    
+    Ok(js_array.into())
+}
+
+/// Get statistics about parsed files and cache.
+#[wasm_bindgen]
+pub fn get_ast_stats() -> Result<JsValue, JsValue> {
+    let stats = PARSE_TREE_CACHE.stats();
+    let manager = get_index_manager();
+    let index = manager.active_index();
+    
+    let obj = js_sys::Object::new();
+    
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("cacheHits"),
+        &JsValue::from(stats.hits),
+    )?;
+    
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("cacheMisses"),
+        &JsValue::from(stats.misses),
+    )?;
+    
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("cachedTrees"),
+        &JsValue::from(stats.tree_count),
+    )?;
+    
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("cacheMemoryUsage"),
+        &JsValue::from(stats.memory_usage),
+    )?;
+    
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("hitRate"),
+        &JsValue::from(PARSE_TREE_CACHE.hit_rate()),
+    )?;
+    
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("totalFiles"),
+        &JsValue::from(index.len()),
+    )?;
+    
+    Ok(obj.into())
+}
+
+/// Clear the parse tree cache.
+#[wasm_bindgen]
+pub fn clear_ast_cache() {
+    PARSE_TREE_CACHE.clear();
+}
+
+/// Get supported languages as a JSON array.
+#[wasm_bindgen]
+pub fn get_supported_languages() -> JsValue {
+    let languages: Vec<&str> = SupportedLanguage::all()
+        .iter()
+        .map(|lang| lang.display_name())
+        .collect();
+    
+    to_value(&languages).unwrap_or(JsValue::NULL)
+}
+
+/// Parse a single file and return whether it was successful.
+#[wasm_bindgen]
+pub fn parse_file(path: &str, content: &[u8], language: &str) -> Result<bool, JsValue> {
+    let path_key = create_path_key(path)
+        .map_err(|e| JsValue::from_str(&format!("Invalid path: {}", e)))?;
+    
+    let lang = parse_language(language)?;
+    
+    match ParseTree::parse(Arc::from(content), lang, path_key.clone()) {
+        Ok(tree) => {
+            // Cache the tree with current timestamp
+            let mtime = js_sys::Date::now() as i64 / 1000;
+            let size = content.len() as u64;
+            PARSE_TREE_CACHE.insert(path_key, tree, mtime, size);
+            Ok(true)
+        }
+        Err(e) => {
+            web_sys::console::warn_1(&format!("Parse failed: {}", e).into());
+            Ok(false)
+        }
+    }
+}
+
+/// Helper function to parse language string.
+fn parse_language(lang_str: &str) -> Result<SupportedLanguage, JsValue> {
+    match lang_str.to_lowercase().as_str() {
+        "javascript" | "js" => Ok(SupportedLanguage::JavaScript),
+        "typescript" | "ts" => Ok(SupportedLanguage::TypeScript),
+        "rust" | "rs" => Ok(SupportedLanguage::Rust),
+        "python" | "py" => Ok(SupportedLanguage::Python),
+        "go" => Ok(SupportedLanguage::Go),
+        "java" => Ok(SupportedLanguage::Java),
+        _ => Err(JsValue::from_str(&format!("Unsupported language: {}", lang_str))),
+    }
+}
+
+/// Get common pattern templates for a language.
+#[wasm_bindgen]
+pub fn get_pattern_templates(language: &str) -> Result<JsValue, JsValue> {
+    use conduit_core::ast::pattern::templates;
+    
+    let lang = parse_language(language)?;
+    
+    let obj = js_sys::Object::new();
+    
+    // Add function pattern
+    let func_pattern = templates::function_definition(lang);
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("functionDefinition"),
+        &JsValue::from_str(func_pattern.pattern()),
+    )?;
+    
+    // Add class pattern
+    let class_pattern = templates::class_definition(lang);
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("classDefinition"),
+        &JsValue::from_str(class_pattern.pattern()),
+    )?;
+    
+    // Add import pattern
+    let import_pattern = templates::imports(lang);
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("imports"),
+        &JsValue::from_str(import_pattern.pattern()),
+    )?;
+    
+    // Add variable pattern
+    let var_pattern = templates::variable_declaration(lang);
+    js_sys::Reflect::set(
+        &obj,
+        &JsValue::from_str("variableDeclaration"),
+        &JsValue::from_str(var_pattern.pattern()),
+    )?;
+    
+    Ok(obj.into())
+}

--- a/crates/conduit-wasm/src/lib.rs
+++ b/crates/conduit-wasm/src/lib.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::prelude::*;
 
 mod globals;
 mod orchestrator;
+mod ast;
 
 // Helper macro for consistent error conversion
 macro_rules! js_err {

--- a/packages/fs/src/ast-service.ts
+++ b/packages/fs/src/ast-service.ts
@@ -1,0 +1,247 @@
+import * as wasm from '@conduit/wasm';
+import type { 
+  AstQuery, 
+  AstMatch, 
+  AstStats, 
+  SupportedLanguage,
+  PatternTemplates 
+} from '@conduit/wasm/ast';
+import { createLogger, ErrorCodes, wrapError } from '@conduit/shared';
+
+const logger = createLogger('ast-service');
+
+/**
+ * Service for performing AST-based structural code searches using tree-sitter.
+ */
+export class AstService {
+  private initialized = false;
+  private parsedLanguages = new Set<SupportedLanguage>();
+
+  /**
+   * Initialize the AST service and parse indexed files.
+   */
+  async initialize(options?: {
+    languages?: SupportedLanguage[];
+    maxFiles?: number;
+  }): Promise<number> {
+    try {
+      // Ensure WASM is initialized
+      if (!this.initialized) {
+        try {
+          wasm.ping();
+        } catch {
+          await wasm.default();
+          wasm.init();
+        }
+        this.initialized = true;
+      }
+
+      // Parse files for specified languages
+      let totalParsed = 0;
+      const languages = options?.languages || this.getSupportedLanguages();
+      
+      for (const lang of languages) {
+        const parsed = wasm.parse_indexed_files(lang, options?.maxFiles);
+        totalParsed += parsed;
+        this.parsedLanguages.add(lang);
+        logger.info(`Parsed ${parsed} ${lang} files`);
+      }
+
+      logger.info(`AST service initialized with ${totalParsed} parsed files`);
+      return totalParsed;
+    } catch (error) {
+      throw wrapError(error, ErrorCodes.WASM_EXECUTION_ERROR, {
+        operation: 'ast-initialize'
+      });
+    }
+  }
+
+  /**
+   * Search for patterns in parsed files.
+   */
+  async search(query: AstQuery): Promise<AstMatch[]> {
+    if (!this.initialized) {
+      throw new Error('AST service not initialized. Call initialize() first.');
+    }
+
+    try {
+      const queryJson = JSON.stringify(query);
+      const results = wasm.ast_search(queryJson);
+      
+      logger.debug(`AST search found ${results.length} matches`, { query });
+      return results;
+    } catch (error) {
+      throw wrapError(error, ErrorCodes.SEARCH_ERROR, {
+        operation: 'ast-search',
+        pattern: query.pattern
+      });
+    }
+  }
+
+  /**
+   * Search for function definitions.
+   */
+  async findFunctions(options?: {
+    language?: SupportedLanguage;
+    maxResults?: number;
+  }): Promise<AstMatch[]> {
+    const templates = this.getPatternTemplates(options?.language || 'javascript');
+    return this.search({
+      pattern: templates.functionDefinition,
+      language: options?.language,
+      maxResults: options?.maxResults,
+      contextLines: 2
+    });
+  }
+
+  /**
+   * Search for class definitions.
+   */
+  async findClasses(options?: {
+    language?: SupportedLanguage;
+    maxResults?: number;
+  }): Promise<AstMatch[]> {
+    const templates = this.getPatternTemplates(options?.language || 'javascript');
+    return this.search({
+      pattern: templates.classDefinition,
+      language: options?.language,
+      maxResults: options?.maxResults,
+      contextLines: 2
+    });
+  }
+
+  /**
+   * Search for imports.
+   */
+  async findImports(options?: {
+    language?: SupportedLanguage;
+    maxResults?: number;
+  }): Promise<AstMatch[]> {
+    const templates = this.getPatternTemplates(options?.language || 'javascript');
+    return this.search({
+      pattern: templates.imports,
+      language: options?.language,
+      maxResults: options?.maxResults,
+      contextLines: 0
+    });
+  }
+
+  /**
+   * Search for specific identifier usage.
+   */
+  async findIdentifier(
+    identifier: string,
+    options?: {
+      language?: SupportedLanguage;
+      maxResults?: number;
+    }
+  ): Promise<AstMatch[]> {
+    // Create a pattern to find the identifier
+    const pattern = `(identifier) @id (#eq? @id "${identifier}")`;
+    
+    return this.search({
+      pattern,
+      language: options?.language,
+      maxResults: options?.maxResults,
+      contextLines: 2
+    });
+  }
+
+  /**
+   * Parse a single file for AST search.
+   */
+  async parseFile(path: string, content: Uint8Array, language: SupportedLanguage): Promise<boolean> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+
+    try {
+      const success = wasm.parse_file(path, content, language);
+      if (success) {
+        logger.debug(`Successfully parsed file: ${path}`);
+      } else {
+        logger.warn(`Failed to parse file: ${path}`);
+      }
+      return success;
+    } catch (error) {
+      throw wrapError(error, ErrorCodes.PARSE_ERROR, {
+        operation: 'parse-file',
+        path,
+        language
+      });
+    }
+  }
+
+  /**
+   * Get statistics about the AST service.
+   */
+  getStats(): AstStats {
+    if (!this.initialized) {
+      return {
+        cacheHits: 0,
+        cacheMisses: 0,
+        cachedTrees: 0,
+        cacheMemoryUsage: 0,
+        hitRate: 0,
+        totalFiles: 0
+      };
+    }
+
+    return wasm.get_ast_stats();
+  }
+
+  /**
+   * Clear the parse tree cache.
+   */
+  clearCache(): void {
+    if (this.initialized) {
+      wasm.clear_ast_cache();
+      this.parsedLanguages.clear();
+      logger.info('AST cache cleared');
+    }
+  }
+
+  /**
+   * Get supported languages.
+   */
+  getSupportedLanguages(): SupportedLanguage[] {
+    if (!this.initialized) {
+      return ['javascript', 'typescript', 'rust', 'python', 'go', 'java'];
+    }
+    return wasm.get_supported_languages() as SupportedLanguage[];
+  }
+
+  /**
+   * Get pattern templates for a language.
+   */
+  getPatternTemplates(language: SupportedLanguage): PatternTemplates {
+    if (!this.initialized) {
+      // Return empty templates if not initialized
+      return {
+        functionDefinition: '',
+        classDefinition: '',
+        imports: '',
+        variableDeclaration: ''
+      };
+    }
+    
+    return wasm.get_pattern_templates(language);
+  }
+
+  /**
+   * Check if a language has been parsed.
+   */
+  isLanguageParsed(language: SupportedLanguage): boolean {
+    return this.parsedLanguages.has(language);
+  }
+
+  /**
+   * Get languages that have been parsed.
+   */
+  getParsedLanguages(): SupportedLanguage[] {
+    return Array.from(this.parsedLanguages);
+  }
+}
+
+// Export singleton instance
+export const astService = new AstService();

--- a/packages/fs/src/index.ts
+++ b/packages/fs/src/index.ts
@@ -7,6 +7,7 @@
 // Main exports
 export { FileScanner } from './scanner.js';
 export { FileService } from './file-service.js';
+export { AstService, astService } from './ast-service.js';
 
 // Types
 export type { 
@@ -19,6 +20,15 @@ export type {
   FileServiceConfig, 
   FileServiceStats
 } from './file-service.js';
+
+// AST Types
+export type {
+  AstQuery,
+  AstMatch,
+  AstStats,
+  SupportedLanguage,
+  PatternTemplates
+} from '@conduit/wasm/ast';
 
 // Utilities
 export { isFileHandle, isDirectoryHandle, isFileSystemAccessSupported } from './types.js';

--- a/packages/wasm/ast.d.ts
+++ b/packages/wasm/ast.d.ts
@@ -1,0 +1,94 @@
+/**
+ * TypeScript definitions for AST-based search functionality in WASM
+ */
+
+export type SupportedLanguage = 
+  | 'javascript'
+  | 'typescript' 
+  | 'rust'
+  | 'python'
+  | 'go'
+  | 'java';
+
+export interface AstQuery {
+  /** The pattern to search for (tree-sitter query syntax) */
+  pattern: string;
+  /** Optional language filter */
+  language?: SupportedLanguage;
+  /** Maximum number of results to return */
+  maxResults?: number;
+  /** Include context lines around matches */
+  contextLines?: number;
+}
+
+export interface AstMatch {
+  /** Path to the file containing the match */
+  path: string;
+  /** Byte span of the match in the source file */
+  span: {
+    start: number;
+    end: number;
+  };
+  /** The matched text */
+  text: string;
+  /** Line number where the match starts (1-based) */
+  line: number;
+  /** Column number where the match starts (1-based) */
+  column: number;
+  /** Language of the matched file */
+  language: SupportedLanguage;
+  /** Optional context around the match */
+  context?: {
+    before: string[];
+    line: string;
+    after: string[];
+  };
+}
+
+export interface AstStats {
+  /** Number of cache hits */
+  cacheHits: number;
+  /** Number of cache misses */
+  cacheMisses: number;
+  /** Number of cached parse trees */
+  cachedTrees: number;
+  /** Cache memory usage in bytes */
+  cacheMemoryUsage: number;
+  /** Cache hit rate (0.0 to 1.0) */
+  hitRate: number;
+  /** Total files in index */
+  totalFiles: number;
+}
+
+export interface PatternTemplates {
+  /** Pattern for finding function definitions */
+  functionDefinition: string;
+  /** Pattern for finding class definitions */
+  classDefinition: string;
+  /** Pattern for finding imports */
+  imports: string;
+  /** Pattern for finding variable declarations */
+  variableDeclaration: string;
+}
+
+// WASM function exports
+export function parse_indexed_files(
+  languageFilter?: string,
+  maxFiles?: number
+): number;
+
+export function ast_search(queryJson: string): AstMatch[];
+
+export function get_ast_stats(): AstStats;
+
+export function clear_ast_cache(): void;
+
+export function get_supported_languages(): string[];
+
+export function parse_file(
+  path: string,
+  content: Uint8Array,
+  language: string
+): boolean;
+
+export function get_pattern_templates(language: string): PatternTemplates;


### PR DESCRIPTION
Add AST-based structural code search using tree-sitter in WASM to enable powerful, syntax-aware queries over indexed files in the browser.

This feature allows users to perform structural code searches (e.g., find all function definitions, class declarations, or specific variable usages) directly within the browser, leveraging tree-sitter's parsing capabilities. This provides a more precise and context-aware alternative to simple text or regex searches, significantly enhancing code exploration and analysis for supported languages (JS/TS, Rust, Python, Go, Java).

---
<a href="https://cursor.com/background-agent?bcId=bc-e6b791a1-eae5-4d64-a9a3-ca8679054ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6b791a1-eae5-4d64-a9a3-ca8679054ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

